### PR TITLE
Only build on pushes to `master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,8 @@
 
 language: generic
 
+branches:
+  only:
+    - master
+
 script: make test


### PR DESCRIPTION
PRs are automatically handled so those branches don't need to have a
double build (once for the PR, once for the push to another branch).

We don't use any other branches besides `master`, so this will save us
CPU cycles.