### PR TITLE
Also run tests on macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dist: bionic
+sudo: false
+
 language: generic
+
+os:
+  - linux
+  - osx
 
 branches:
   only:
     - master
+
+matrix:
+  allow_failures:
+    - os: osx
+
+  fast_finish: true
 
 script: make test


### PR DESCRIPTION
However, allow them to fail (or hang/timeout, if there aren't enough
macOS compute resources), so that our progress isn't blocked, since
Linux VMs are plentiful.